### PR TITLE
Baseline spec + rename to Docker-in-LXC

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,7 +6,7 @@ The work described here is **complete**. Keeping it for reference.
 ## What Was Done (2026-02-11)
 
 ### Problem
-The `claude-sandbox` LXD container had no IPv4 connectivity. It got an IPv6 address
+The `docker-lxc` LXD container had no IPv4 connectivity. It got an IPv6 address
 from lxdbr0 but couldn't get a DHCP lease or reach the internet. The container was
 partially provisioned (no software installed).
 

--- a/constitution-input.md
+++ b/constitution-input.md
@@ -14,7 +14,7 @@ Each script runs in exactly one place:
 
 - `setup-host.sh` — runs on the host, creates and provisions the container
 - `provision-container.sh` — runs inside the container, installs tools and configures the user environment
-- `sandbox.sh` — runs on the host, wraps `lxc` commands for day-to-day use
+- `dilxc.sh` — runs on the host, wraps `lxc` commands for day-to-day use
 
 When adding functionality, add it to the appropriate existing script. Do not create new scripts unless there's a genuinely new execution context.
 
@@ -28,7 +28,7 @@ LXD is the security boundary. Don't add sandboxing layers inside the container �
 
 ### Don't touch the host
 
-The host is a shared machine running other services — Docker stacks, other LXD containers, production workloads. Every `lxc` command is scoped to `$CLAUDE_SANDBOX`. Never operate on other containers, never modify host-level config, never assume the sandbox is the only thing running. Each container is independent: one project mount, its own snapshots, no cross-container state.
+The host is a shared machine running other services — Docker stacks, other LXD containers, production workloads. Every `lxc` command is scoped to `$DILXC_CONTAINER`. Never operate on other containers, never modify host-level config, never assume the sandbox is the only thing running. Each container is independent: one project mount, its own snapshots, no cross-container state.
 
 ### LXD today, Incus eventually
 
@@ -48,11 +48,11 @@ Bash configuration is always written. Fish is only configured when the `--fish` 
 
 ### Error handling
 
-`setup-host.sh` and `provision-container.sh` use `set -euo pipefail`. If setup fails partway, the recovery path is deleting the container and starting over, not trying to resume. `sandbox.sh` does not use `set -e` because it needs to handle failures gracefully in individual commands.
+`setup-host.sh` and `provision-container.sh` use `set -euo pipefail`. If setup fails partway, the recovery path is deleting the container and starting over, not trying to resume. `dilxc.sh` does not use `set -e` because it needs to handle failures gracefully in individual commands.
 
 ### Rsync excludes stay synchronized
 
-The rsync exclude list (`node_modules`, `.git`, `dist`, `build`) appears in three places: the bash `sync-project` function, the fish `sync-project` function, and the `sandbox.sh sync` command. These must always match.
+The rsync exclude list (`node_modules`, `.git`, `dist`, `build`) appears in three places: the bash `sync-project` function, the fish `sync-project` function, and the `dilxc.sh sync` command. These must always match.
 
 ### Keep arguments safe
 

--- a/dilxc.sh
+++ b/dilxc.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # =============================================================================
-# Claude Code LXD Sandbox - Management Helper
-# Common operations for your sandbox
+# Docker-in-LXC - Management Helper
+# Common operations for your container
 # =============================================================================
 
-CONTAINER_NAME="${CLAUDE_SANDBOX:-claude-sandbox}"
+CONTAINER_NAME="${DILXC_CONTAINER:-docker-lxc}"
 
 usage() {
   cat << EOF
-Usage: ./sandbox.sh <command> [options]
+Usage: ./dilxc.sh <command> [options]
 
 Commands:
   shell                  Open a shell in the container as ubuntu user
@@ -39,20 +39,20 @@ Commands:
   destroy                Delete the container entirely (asks for confirmation)
 
 Environment:
-  CLAUDE_SANDBOX         Container name (default: claude-sandbox)
+  DILXC_CONTAINER        Container name (default: docker-lxc)
 
 Examples:
-  ./sandbox.sh login                                  # first-time auth
-  ./sandbox.sh shell
-  ./sandbox.sh claude
-  ./sandbox.sh claude-run "fix the failing tests in src/api/"
-  ./sandbox.sh claude-resume                          # pick up where you left off
-  ./sandbox.sh exec npm test                          # run a command in project dir
-  ./sandbox.sh snapshot before-big-refactor
-  ./sandbox.sh restore before-big-refactor
-  ./sandbox.sh pull /home/ubuntu/project/dist/ ./dist/
-  ./sandbox.sh docker compose logs -f
-  ./sandbox.sh health-check
+  ./dilxc.sh login                                  # first-time auth
+  ./dilxc.sh shell
+  ./dilxc.sh claude
+  ./dilxc.sh claude-run "fix the failing tests in src/api/"
+  ./dilxc.sh claude-resume                          # pick up where you left off
+  ./dilxc.sh exec npm test                          # run a command in project dir
+  ./dilxc.sh snapshot before-big-refactor
+  ./dilxc.sh restore before-big-refactor
+  ./dilxc.sh pull /home/ubuntu/project/dist/ ./dist/
+  ./dilxc.sh docker compose logs -f
+  ./dilxc.sh health-check
 EOF
 }
 
@@ -72,7 +72,7 @@ require_running() {
   state=$(lxc info "$CONTAINER_NAME" | grep -oP 'Status: \K\w+')
   if [[ "$state" != "RUNNING" ]]; then
     echo "Error: container '$CONTAINER_NAME' is $state (not running)"
-    echo "  Start it with: ./sandbox.sh start"
+    echo "  Start it with: ./dilxc.sh start"
     exit 1
   fi
 }
@@ -155,7 +155,7 @@ cmd_claude_run() {
   local prompt="$1"
   if [[ -z "$prompt" ]]; then
     echo "Error: provide a prompt string"
-    echo "  ./sandbox.sh claude-run \"fix the tests\""
+    echo "  ./dilxc.sh claude-run \"fix the tests\""
     exit 1
   fi
   local escaped
@@ -184,7 +184,7 @@ cmd_exec() {
   require_running
   if [[ $# -eq 0 ]]; then
     echo "Error: provide a command to run"
-    echo "  ./sandbox.sh exec npm test"
+    echo "  ./dilxc.sh exec npm test"
     exit 1
   fi
   local cmd=""
@@ -201,7 +201,7 @@ cmd_pull() {
   local dest="${2:-.}"
   if [[ -z "$src" ]]; then
     echo "Error: specify path to pull"
-    echo "  ./sandbox.sh pull /home/ubuntu/project/dist/ ./dist/"
+    echo "  ./dilxc.sh pull /home/ubuntu/project/dist/ ./dist/"
     exit 1
   fi
   if lxc file pull -r "$CONTAINER_NAME$src" "$dest"; then

--- a/provision-container.sh
+++ b/provision-container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # =============================================================================
-# Claude Code LXD Sandbox - Container Provisioning
+# Docker-in-LXC - Container Provisioning
 # This runs INSIDE the LXD container (called by setup-host.sh)
 # =============================================================================
 
@@ -78,8 +78,8 @@ echo "--- Configuring ubuntu user ---"
 
 # Set up git defaults (user can override)
 su - ubuntu -c 'git config --global init.defaultBranch main'
-su - ubuntu -c 'git config --global user.name "Claude Code (sandbox)"'
-su - ubuntu -c 'git config --global user.email "claude-sandbox@localhost"'
+su - ubuntu -c 'git config --global user.name "Claude Code (docker-lxc)"'
+su - ubuntu -c 'git config --global user.email "docker-lxc@localhost"'
 
 # Create a working directory
 su - ubuntu -c 'mkdir -p /home/ubuntu/project'

--- a/setup-host.sh
+++ b/setup-host.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # =============================================================================
-# Claude Code LXD Sandbox - Host Setup Script
+# Docker-in-LXC - Host Setup Script
 # Run this on your Ubuntu homelab server
 # =============================================================================
 
@@ -13,14 +13,14 @@ Usage: ./setup-host.sh [options]
 Creates an LXD container with Claude Code, Docker, and dev tools.
 
 Options:
-  -n, --name <name>      Container name (default: \$CLAUDE_SANDBOX or claude-sandbox)
+  -n, --name <name>      Container name (default: \$DILXC_CONTAINER or docker-lxc)
   -p, --project <path>   Host project directory to mount read-only
   -d, --deploy <path>    Host directory to mount read-write for deploy output
   -f, --fish             Install fish shell and set as default (default: bash only)
   -h, --help             Show this help message
 
 Examples:
-  ./setup-host.sh -n claude-sandbox -p /home/john/dev/myproject/
+  ./setup-host.sh -n docker-lxc -p /home/john/dev/myproject/
   ./setup-host.sh -p /home/john/dev/myproject/ --fish
   ./setup-host.sh -p /home/john/dev/myproject/ -d /srv/www
   ANTHROPIC_API_KEY=sk-... ./setup-host.sh -p /path/to/project
@@ -28,7 +28,7 @@ EOF
 }
 
 # --- Configuration -----------------------------------------------------------
-CONTAINER_NAME="${CLAUDE_SANDBOX:-claude-sandbox}"
+CONTAINER_NAME="${DILXC_CONTAINER:-docker-lxc}"
 UBUNTU_VERSION="24.04"
 PROJECT_PATH=""
 DEPLOY_PATH=""
@@ -53,7 +53,7 @@ if [[ -z "$PROJECT_PATH" ]]; then
 fi
 
 echo "============================================="
-echo "  Claude Code LXD Sandbox Setup"
+echo "  Docker-in-LXC Setup"
 echo "  Container: $CONTAINER_NAME"
 echo "============================================="
 echo ""
@@ -167,7 +167,7 @@ else
   echo "  Claude Pro/Max subscribers: authenticate via browser login."
   echo "  After setup completes, run:"
   echo ""
-  echo "    ./sandbox.sh login"
+  echo "    ./dilxc.sh login"
   echo ""
   echo "  This opens an interactive Claude session where you can complete"
   echo "  the OAuth flow in your browser. You only need to do this once."
@@ -190,13 +190,13 @@ echo "============================================="
 echo ""
 echo "  Quick reference:"
 echo ""
-echo "  ./sandbox.sh shell                # shell into the container"
-echo "  ./sandbox.sh sync                 # copy project source to working dir"
-echo "  ./sandbox.sh claude               # start Claude Code (autonomous)"
-echo "  ./sandbox.sh claude-run \"prompt\"   # one-shot Claude Code"
-echo "  ./sandbox.sh claude-resume        # resume last session"
-echo "  ./sandbox.sh snapshot <name>      # btrfs snapshot"
-echo "  ./sandbox.sh restore <name>       # instant rollback"
-echo "  ./sandbox.sh pull <path> [dest]   # pull files to host"
-echo "  ./sandbox.sh health-check         # verify everything works"
+echo "  ./dilxc.sh shell                # shell into the container"
+echo "  ./dilxc.sh sync                 # copy project source to working dir"
+echo "  ./dilxc.sh claude               # start Claude Code (autonomous)"
+echo "  ./dilxc.sh claude-run \"prompt\"   # one-shot Claude Code"
+echo "  ./dilxc.sh claude-resume        # resume last session"
+echo "  ./dilxc.sh snapshot <name>      # btrfs snapshot"
+echo "  ./dilxc.sh restore <name>       # instant rollback"
+echo "  ./dilxc.sh pull <path> [dest]   # pull files to host"
+echo "  ./dilxc.sh health-check         # verify everything works"
 echo ""

--- a/spec-input.md
+++ b/spec-input.md
@@ -17,7 +17,7 @@ The user runs `setup-host.sh` on their Ubuntu host to create a sandbox:
 - Pushes and executes the provisioning script inside the container
 - Takes a `clean-baseline` btrfs snapshot when done
 
-The container name defaults to `claude-sandbox` but is configurable via `-n` flag or `CLAUDE_SANDBOX` env var.
+The container name defaults to `docker-lxc` but is configurable via `-n` flag or `DILXC_CONTAINER` env var.
 
 If setup fails partway through, the user deletes the container and starts fresh.
 
@@ -44,10 +44,10 @@ Fish shell is opt-in via `--fish` flag: installs fish, writes equivalent config 
 
 Two methods:
 
-1. **Browser OAuth** (primary): After setup, the user runs `./sandbox.sh login`, which opens an interactive Claude session. They complete the OAuth flow in their browser and exit. One-time step.
+1. **Browser OAuth** (primary): After setup, the user runs `./dilxc.sh login`, which opens an interactive Claude session. They complete the OAuth flow in their browser and exit. One-time step.
 2. **API key** (alternative): Set `ANTHROPIC_API_KEY` env var before running `setup-host.sh`. The key gets written into shell config inside the container.
 
-## Daily workflow (`sandbox.sh`)
+## Daily workflow (`dilxc.sh`)
 
 The management wrapper provides these operations:
 
@@ -83,7 +83,7 @@ The management wrapper provides these operations:
 
 ## Multiple sandboxes
 
-Set `CLAUDE_SANDBOX=other-name` env var before any `sandbox.sh` command to operate on a different container. Same variable is respected by `setup-host.sh` for the default container name.
+Set `DILXC_CONTAINER=other-name` env var before any `dilxc.sh` command to operate on a different container. Same variable is respected by `setup-host.sh` for the default container name.
 
 Each container is bound to one project directory, set at creation via `--project`. Containers are fully isolated — separate project mounts, independent snapshots, no shared state. Spin up a new container per project, prefix commands with the env var, destroy when done.
 

--- a/specs/001-baseline-spec/checklists/requirements.md
+++ b/specs/001-baseline-spec/checklists/requirements.md
@@ -1,4 +1,4 @@
-# Specification Quality Checklist: LXD Sandbox for Autonomous Claude Code
+# Specification Quality Checklist: Docker-in-LXC
 
 **Purpose**: Validate specification completeness and quality before proceeding to planning
 **Created**: 2026-02-11
@@ -33,5 +33,5 @@
 
 - This is a baseline spec documenting already-built functionality. All requirements are derived from the existing, working implementation.
 - No [NEEDS CLARIFICATION] markers were needed — the feature description was comprehensive and complete.
-- The spec references specific CLI commands and paths (e.g., `sandbox.sh claude`, `/home/ubuntu/project`) because these are user-facing interface contracts, not implementation details. They describe WHAT the user interacts with, not HOW the system implements it internally.
+- The spec references specific CLI commands and paths (e.g., `dilxc.sh claude`, `/home/ubuntu/project`) because these are user-facing interface contracts, not implementation details. They describe WHAT the user interacts with, not HOW the system implements it internally.
 - All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/001-baseline-spec/contracts/provision.md
+++ b/specs/001-baseline-spec/contracts/provision.md
@@ -70,8 +70,8 @@ Written to `/home/ubuntu/.config/fish/config.fish`:
 | Config | Value |
 |--------|-------|
 | `init.defaultBranch` | `main` |
-| `user.name` | `Claude Code (sandbox)` |
-| `user.email` | `claude-sandbox@localhost` |
+| `user.name` | `Claude Code (docker-lxc)` |
+| `user.email` | `docker-lxc@localhost` |
 
 ## Exit Codes
 

--- a/specs/001-baseline-spec/contracts/sandbox.md
+++ b/specs/001-baseline-spec/contracts/sandbox.md
@@ -1,14 +1,14 @@
-# CLI Contract: sandbox.sh
+# CLI Contract: dilxc.sh
 
-**Script**: `sandbox.sh`
+**Script**: `dilxc.sh`
 **Execution context**: Host (Ubuntu homelab server)
 **Error handling**: No `set -e` — handles failures per-command
-**Container selection**: `$CLAUDE_SANDBOX` env var (default: `claude-sandbox`)
+**Container selection**: `$DILXC_CONTAINER` env var (default: `docker-lxc`)
 
 ## Synopsis
 
 ```
-./sandbox.sh <command> [options]
+./dilxc.sh <command> [options]
 ```
 
 ## Subcommands
@@ -81,7 +81,7 @@
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CLAUDE_SANDBOX` | `claude-sandbox` | Target container name for all operations |
+| `DILXC_CONTAINER` | `docker-lxc` | Target container name for all operations |
 
 ## Exit Codes
 
@@ -108,38 +108,38 @@ Three commands use `printf '%q'` for safe shell escaping:
 
 ```bash
 # Authentication
-./sandbox.sh login
+./dilxc.sh login
 
 # Interactive Claude
-./sandbox.sh claude
+./dilxc.sh claude
 
 # One-shot with special characters
-./sandbox.sh claude-run "fix the tests in src/api/ and run 'npm test'"
+./dilxc.sh claude-run "fix the tests in src/api/ and run 'npm test'"
 
 # Resume last session
-./sandbox.sh claude-resume
+./dilxc.sh claude-resume
 
 # Sync project files
-./sandbox.sh sync
+./dilxc.sh sync
 
 # Run a command
-./sandbox.sh exec npm test
+./dilxc.sh exec npm test
 
 # Snapshot workflow
-./sandbox.sh snapshot before-refactor
-./sandbox.sh restore before-refactor
+./dilxc.sh snapshot before-refactor
+./dilxc.sh restore before-refactor
 
 # File transfer
-./sandbox.sh pull /home/ubuntu/project/dist/ ./dist/
-./sandbox.sh push local-file.txt /home/ubuntu/project/
+./dilxc.sh pull /home/ubuntu/project/dist/ ./dist/
+./dilxc.sh push local-file.txt /home/ubuntu/project/
 
 # Docker passthrough
-./sandbox.sh docker compose up -d
-./sandbox.sh docker ps
+./dilxc.sh docker compose up -d
+./dilxc.sh docker ps
 
 # Health check
-./sandbox.sh health-check
+./dilxc.sh health-check
 
 # Multiple sandboxes
-CLAUDE_SANDBOX=project-b ./sandbox.sh claude
+DILXC_CONTAINER=project-b ./dilxc.sh claude
 ```

--- a/specs/001-baseline-spec/contracts/setup-host.md
+++ b/specs/001-baseline-spec/contracts/setup-host.md
@@ -15,7 +15,7 @@
 
 | Flag | Long | Argument | Default | Description |
 |------|------|----------|---------|-------------|
-| `-n` | `--name` | `<name>` | `$CLAUDE_SANDBOX` or `claude-sandbox` | Container name |
+| `-n` | `--name` | `<name>` | `$DILXC_CONTAINER` or `docker-lxc` | Container name |
 | `-p` | `--project` | `<path>` | *(required)* | Host project directory to mount read-only |
 | `-d` | `--deploy` | `<path>` | *(none)* | Host directory to mount read-write for deploy output |
 | `-f` | `--fish` | *(none)* | `false` | Install fish shell and set as default |
@@ -25,7 +25,7 @@
 
 | Variable | Effect |
 |----------|--------|
-| `CLAUDE_SANDBOX` | Default container name if `-n` not specified |
+| `DILXC_CONTAINER` | Default container name if `-n` not specified |
 | `ANTHROPIC_API_KEY` | If set, injected into container's shell config for API key auth |
 
 ## Execution Steps
@@ -63,7 +63,7 @@ Partially idempotent:
 
 ```bash
 # Basic setup
-./setup-host.sh -n claude-sandbox -p /home/john/dev/myproject/
+./setup-host.sh -n docker-lxc -p /home/john/dev/myproject/
 
 # With fish shell
 ./setup-host.sh -p /home/john/dev/myproject/ --fish

--- a/specs/001-baseline-spec/data-model.md
+++ b/specs/001-baseline-spec/data-model.md
@@ -1,4 +1,4 @@
-# Data Model: LXD Sandbox for Autonomous Claude Code
+# Data Model: Docker-in-LXC
 
 **Branch**: `001-baseline-spec` | **Date**: 2026-02-11
 
@@ -10,7 +10,7 @@ The primary entity. An LXD system container bound to a single host project.
 
 | Field | Type | Source | Notes |
 |-------|------|--------|-------|
-| name | string | `$CLAUDE_SANDBOX` or `-n` flag | Default: `claude-sandbox` |
+| name | string | `$DILXC_CONTAINER` or `-n` flag | Default: `docker-lxc` |
 | image | string | hardcoded | `ubuntu:24.04` |
 | status | enum | `lxc info` | `RUNNING`, `STOPPED`, `FROZEN` |
 | nesting | bool | config | Always `true` (Docker support) |
@@ -22,7 +22,7 @@ The primary entity. An LXD system container bound to a single host project.
 **Validation rules**:
 - Name must be a valid LXD container name (alphanumeric + hyphens)
 - Project mount source path must exist on host before setup
-- Container must exist before any `sandbox.sh` operation (`require_container`)
+- Container must exist before any `dilxc.sh` operation (`require_container`)
 - Container must be RUNNING for most operations (`require_running`)
 
 **State transitions**:
@@ -93,8 +93,8 @@ Not an LXD entity — a filesystem directory managed by rsync.
 
 **Validation rules**:
 - Directory created during provisioning (`mkdir -p`)
-- Content populated post-setup by user running `sandbox.sh sync` (not during provisioning)
-- Exclude lists must match across bash config, fish config, and `sandbox.sh sync`
+- Content populated post-setup by user running `dilxc.sh sync` (not during provisioning)
+- Exclude lists must match across bash config, fish config, and `dilxc.sh sync`
 
 ## Relationships
 

--- a/specs/001-baseline-spec/quickstart.md
+++ b/specs/001-baseline-spec/quickstart.md
@@ -1,4 +1,4 @@
-# Quickstart: LXD Sandbox for Autonomous Claude Code
+# Quickstart: Docker-in-LXC
 
 ## Prerequisites
 
@@ -11,13 +11,13 @@
 
 ```bash
 # Basic setup — mount your project read-only
-./setup-host.sh -n claude-sandbox -p /home/john/dev/myproject/
+./setup-host.sh -n docker-lxc -p /home/john/dev/myproject/
 
 # With fish shell as default
-./setup-host.sh -n claude-sandbox -p /home/john/dev/myproject/ --fish
+./setup-host.sh -n docker-lxc -p /home/john/dev/myproject/ --fish
 
 # With deploy mount for pushing output back to host
-./setup-host.sh -n claude-sandbox -p /home/john/dev/myproject/ -d /srv/www
+./setup-host.sh -n docker-lxc -p /home/john/dev/myproject/ -d /srv/www
 ```
 
 Setup creates the container, installs all tooling (Docker, Node.js, Claude Code, uv, Spec Kit), and takes a `clean-baseline` snapshot.
@@ -26,7 +26,7 @@ Setup creates the container, installs all tooling (Docker, Node.js, Claude Code,
 
 ```bash
 # Browser OAuth (Claude Max subscribers)
-./sandbox.sh login
+./dilxc.sh login
 # Complete the flow in your browser, then exit with /exit
 
 # OR: API key (set before running setup-host.sh)
@@ -37,53 +37,53 @@ ANTHROPIC_API_KEY=sk-... ./setup-host.sh -p /path/to/project
 
 ```bash
 # Copy project files from read-only mount to writable working directory
-./sandbox.sh sync
+./dilxc.sh sync
 ```
 
 ## 4. Run Claude Code
 
 ```bash
 # Interactive session (autonomous mode)
-./sandbox.sh claude
+./dilxc.sh claude
 
 # One-shot prompt
-./sandbox.sh claude-run "refactor the auth module and run tests"
+./dilxc.sh claude-run "refactor the auth module and run tests"
 
 # Resume last session
-./sandbox.sh claude-resume
+./dilxc.sh claude-resume
 ```
 
 ## 5. Snapshot Before Risky Operations
 
 ```bash
 # Take a named snapshot
-./sandbox.sh snapshot before-big-refactor
+./dilxc.sh snapshot before-big-refactor
 
 # If something goes wrong, instant rollback
-./sandbox.sh restore before-big-refactor
+./dilxc.sh restore before-big-refactor
 
 # List all snapshots
-./sandbox.sh snapshots
+./dilxc.sh snapshots
 ```
 
 ## 6. Get Files Out
 
 ```bash
 # Pull files from container to host
-./sandbox.sh pull /home/ubuntu/project/dist/ ./dist/
+./dilxc.sh pull /home/ubuntu/project/dist/ ./dist/
 
 # Or push from host to container
-./sandbox.sh push local-file.txt /home/ubuntu/project/
+./dilxc.sh push local-file.txt /home/ubuntu/project/
 ```
 
 ## Common Operations
 
 ```bash
-./sandbox.sh shell              # Interactive shell
-./sandbox.sh exec npm test      # Run a command in the project dir
-./sandbox.sh docker ps          # Docker commands inside sandbox
-./sandbox.sh health-check       # Verify everything works
-./sandbox.sh status             # Container info + snapshots
+./dilxc.sh shell              # Interactive shell
+./dilxc.sh exec npm test      # Run a command in the project dir
+./dilxc.sh docker ps          # Docker commands inside sandbox
+./dilxc.sh health-check       # Verify everything works
+./dilxc.sh status             # Container info + snapshots
 ```
 
 ## Multiple Sandboxes
@@ -93,11 +93,11 @@ ANTHROPIC_API_KEY=sk-... ./setup-host.sh -p /path/to/project
 ./setup-host.sh -n project-b -p /home/john/dev/other-project/
 
 # Operate on it
-CLAUDE_SANDBOX=project-b ./sandbox.sh claude
+DILXC_CONTAINER=project-b ./dilxc.sh claude
 ```
 
 ## Important Notes
 
-- **Sync is destructive**: `sandbox.sh sync` uses `rsync --delete` — files only in the working copy are removed. Commit and push to GitHub before syncing.
+- **Sync is destructive**: `dilxc.sh sync` uses `rsync --delete` — files only in the working copy are removed. Commit and push to GitHub before syncing.
 - **The container IS the sandbox**: Claude runs with `--dangerously-skip-permissions`. If something goes wrong, restore a snapshot.
-- **Setup failures**: Delete the container (`./sandbox.sh destroy`) and re-run `setup-host.sh`.
+- **Setup failures**: Delete the container (`./dilxc.sh destroy`) and re-run `setup-host.sh`.

--- a/specs/001-baseline-spec/research.md
+++ b/specs/001-baseline-spec/research.md
@@ -1,4 +1,4 @@
-# Research: LXD Sandbox for Autonomous Claude Code
+# Research: Docker-in-LXC
 
 **Branch**: `001-baseline-spec` | **Date**: 2026-02-11
 **Context**: Baseline spec — documenting decisions already made in the existing implementation.
@@ -83,7 +83,7 @@
 
 ## Decision 8: Destructive Sync (rsync --delete)
 
-**Decision**: `sync-project` and `sandbox.sh sync` use `rsync --delete`, removing any files in the working copy that don't exist in the source mount.
+**Decision**: `sync-project` and `dilxc.sh sync` use `rsync --delete`, removing any files in the working copy that don't exist in the source mount.
 
 **Rationale**: Sync is a full reset operation — the working copy should match the source exactly. This is the safest model: the user knows exactly what they'll get after a sync. The workflow for preserving container changes is to commit and push to GitHub before syncing.
 

--- a/specs/001-baseline-spec/tasks.md
+++ b/specs/001-baseline-spec/tasks.md
@@ -1,4 +1,4 @@
-# Tasks: LXD Sandbox for Autonomous Claude Code
+# Tasks: Docker-in-LXC
 
 **Input**: Design documents from `/specs/001-baseline-spec/`
 **Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
@@ -21,10 +21,10 @@
 
 **Purpose**: Verify project structure matches plan.md and all scripts exist
 
-- [x] T001 Validate project structure matches plan.md layout — verify `setup-host.sh`, `provision-container.sh`, `sandbox.sh`, `CLAUDE.md`, and `.gitignore` exist at repository root
+- [x] T001 Validate project structure matches plan.md layout — verify `setup-host.sh`, `provision-container.sh`, `dilxc.sh`, `CLAUDE.md`, and `.gitignore` exist at repository root
 - [x] T002 [P] Verify `setup-host.sh` uses `set -euo pipefail` and `#!/bin/bash` per contracts/setup-host.md
 - [x] T003 [P] Verify `provision-container.sh` uses `set -euo pipefail` and `#!/bin/bash` per contracts/provision.md
-- [x] T004 [P] Verify `sandbox.sh` uses `#!/bin/bash` and per-command error handling (no `set -e`) per contracts/sandbox.md
+- [x] T004 [P] Verify `dilxc.sh` uses `#!/bin/bash` and per-command error handling (no `set -e`) per contracts/sandbox.md
 
 ---
 
@@ -34,10 +34,10 @@
 
 **CRITICAL**: These checks underpin every user story — failures here indicate systemic issues
 
-- [x] T005 [P] Validate rsync exclude list parity (Constitution XI) — confirm `node_modules`, `.git`, `dist`, `build` are excluded identically in `sandbox.sh` `cmd_sync`, bash `sync-project` function, and fish `sync-project` function within `provision-container.sh`
-- [x] T006 [P] Validate argument escaping (Constitution XII) — verify `printf '%q'` usage in `sandbox.sh` for `cmd_claude_run`, `cmd_exec`, and `cmd_docker` subcommands
-- [x] T007 [P] Validate TTY allocation — verify `-t` flag on `lxc exec` for interactive commands (`shell`, `root`, `login`, `claude`, `claude-resume`) in `sandbox.sh`
-- [x] T008 [P] Validate precondition helpers — verify `require_container` and `require_running` functions exist in `sandbox.sh` and are called before relevant subcommands per contracts/sandbox.md
+- [x] T005 [P] Validate rsync exclude list parity (Constitution XI) — confirm `node_modules`, `.git`, `dist`, `build` are excluded identically in `dilxc.sh` `cmd_sync`, bash `sync-project` function, and fish `sync-project` function within `provision-container.sh`
+- [x] T006 [P] Validate argument escaping (Constitution XII) — verify `printf '%q'` usage in `dilxc.sh` for `cmd_claude_run`, `cmd_exec`, and `cmd_docker` subcommands
+- [x] T007 [P] Validate TTY allocation — verify `-t` flag on `lxc exec` for interactive commands (`shell`, `root`, `login`, `claude`, `claude-resume`) in `dilxc.sh`
+- [x] T008 [P] Validate precondition helpers — verify `require_container` and `require_running` functions exist in `dilxc.sh` and are called before relevant subcommands per contracts/sandbox.md
 - [x] T009 [P] Validate verbose output (FR-023) — confirm all three scripts produce step-by-step progress to stdout and errors to stderr
 - [x] T010 Validate shell parity (Constitution IX) — verify bash config block and fish config block in `provision-container.sh` define identical aliases/abbreviations, functions, and PATH entries per contracts/provision.md
 
@@ -73,16 +73,16 @@
 
 ## Phase 4: User Story 2 — Run Claude Code Autonomously (Priority: P1)
 
-**Goal**: Verify `sandbox.sh` Claude commands launch Claude Code with correct flags in the correct directory
+**Goal**: Verify `dilxc.sh` Claude commands launch Claude Code with correct flags in the correct directory
 
 **Independent Test**: Start an interactive Claude session and a one-shot prompt, verify both operate in `/home/ubuntu/project` with `--dangerously-skip-permissions`
 
 ### Validation for User Story 2
 
-- [x] T024 [US2] Validate `cmd_claude` in `sandbox.sh` — verify interactive Claude Code starts in `/home/ubuntu/project` with `--dangerously-skip-permissions` and TTY (FR-005, FR-010, Acceptance 2.1)
-- [x] T025 [US2] Validate `cmd_claude_run` in `sandbox.sh` — verify one-shot prompt execution with `printf %q` escaping in project directory (FR-011, Acceptance 2.2)
-- [x] T026 [US2] Validate `cmd_claude_resume` in `sandbox.sh` — verify session resume with `--resume` flag and TTY (Acceptance 2.3)
-- [x] T027 [US2] Acceptance test: Run `sandbox.sh claude-run "fix the tests in src/api/ and run 'npm test' -- --grep \"auth module\""` and verify it executes non-interactively with correct working directory and the prompt passes through with quotes and spaces intact (Acceptance 2.2, SC-007) — **verified via exec**: printf %q escaping preserves all special chars through lxc exec chain
+- [x] T024 [US2] Validate `cmd_claude` in `dilxc.sh` — verify interactive Claude Code starts in `/home/ubuntu/project` with `--dangerously-skip-permissions` and TTY (FR-005, FR-010, Acceptance 2.1)
+- [x] T025 [US2] Validate `cmd_claude_run` in `dilxc.sh` — verify one-shot prompt execution with `printf %q` escaping in project directory (FR-011, Acceptance 2.2)
+- [x] T026 [US2] Validate `cmd_claude_resume` in `dilxc.sh` — verify session resume with `--resume` flag and TTY (Acceptance 2.3)
+- [x] T027 [US2] Acceptance test: Run `dilxc.sh claude-run "fix the tests in src/api/ and run 'npm test' -- --grep \"auth module\""` and verify it executes non-interactively with correct working directory and the prompt passes through with quotes and spaces intact (Acceptance 2.2, SC-007) — **verified via exec**: printf %q escaping preserves all special chars through lxc exec chain
 
 **Checkpoint**: User Story 2 validated — Claude Code runs autonomously as specified
 
@@ -92,11 +92,11 @@
 
 **Goal**: Verify authentication pathways (browser OAuth and API key injection)
 
-**Independent Test**: Run `sandbox.sh login` and verify Claude Code can start a session afterward
+**Independent Test**: Run `dilxc.sh login` and verify Claude Code can start a session afterward
 
 ### Validation for User Story 3
 
-- [x] T028 [US3] Validate `cmd_login` in `sandbox.sh` — verify interactive Claude Code session with TTY for browser OAuth flow (FR-012, Acceptance 3.1)
+- [x] T028 [US3] Validate `cmd_login` in `dilxc.sh` — verify interactive Claude Code session with TTY for browser OAuth flow (FR-012, Acceptance 3.1)
 - [x] T029 [US3] Validate API key injection in `setup-host.sh` — verify `ANTHROPIC_API_KEY` env var is written into container shell config when set (FR-012, Acceptance 3.2)
 - [x] T030 [P] [US3] Validate API key written to bash config in `provision-container.sh` — verify export statement appended to `.bashrc` when API key is passed
 - [x] T031 [P] [US3] Validate API key written to fish config in `provision-container.sh` — verify `set -gx` in fish config when API key is passed and `--fish` is used
@@ -113,10 +113,10 @@
 
 ### Validation for User Story 4
 
-- [x] T032 [US4] Validate `cmd_snapshot` in `sandbox.sh` — verify named snapshot creation via `lxc snapshot` (FR-008, Acceptance 4.1)
-- [x] T033 [US4] Validate auto-generated snapshot name in `sandbox.sh` — verify `snap-YYYYMMDD-HHMMSS` format when no name provided (FR-008, Acceptance 4.2)
-- [x] T034 [US4] Validate `cmd_restore` in `sandbox.sh` — verify snapshot restoration with automatic container restart (FR-009, Acceptance 4.3)
-- [x] T035 [P] [US4] Validate `cmd_snapshots` in `sandbox.sh` — verify snapshot listing output (Acceptance 4.4)
+- [x] T032 [US4] Validate `cmd_snapshot` in `dilxc.sh` — verify named snapshot creation via `lxc snapshot` (FR-008, Acceptance 4.1)
+- [x] T033 [US4] Validate auto-generated snapshot name in `dilxc.sh` — verify `snap-YYYYMMDD-HHMMSS` format when no name provided (FR-008, Acceptance 4.2)
+- [x] T034 [US4] Validate `cmd_restore` in `dilxc.sh` — verify snapshot restoration with automatic container restart (FR-009, Acceptance 4.3)
+- [x] T035 [P] [US4] Validate `cmd_snapshots` in `dilxc.sh` — verify snapshot listing output (Acceptance 4.4)
 - [x] T036 [US4] Validate restore error handling — verify missing snapshot name shows available snapshots (per contracts/sandbox.md)
 - [x] T037 [US4] Acceptance test: Take snapshot, create a file in container, restore, verify file is gone and container is running (SC-003)
 
@@ -132,12 +132,12 @@
 
 ### Validation for User Story 5
 
-- [x] T038 [US5] Validate `cmd_sync` in `sandbox.sh` — verify rsync with `--delete` from `project-src/` to `project/` with 4 excludes (FR-006, Acceptance 5.1)
-- [x] T039 [P] [US5] Validate `cmd_pull` in `sandbox.sh` — verify `lxc file pull -r` from container to host with default dest `.` (FR-021, Acceptance 5.2)
-- [x] T040 [P] [US5] Validate `cmd_push` in `sandbox.sh` — verify `lxc file push` from host to container with default dest `/home/ubuntu/project/` (FR-021, Acceptance 5.3)
+- [x] T038 [US5] Validate `cmd_sync` in `dilxc.sh` — verify rsync with `--delete` from `project-src/` to `project/` with 4 excludes (FR-006, Acceptance 5.1)
+- [x] T039 [P] [US5] Validate `cmd_pull` in `dilxc.sh` — verify `lxc file pull -r` from container to host with default dest `.` (FR-021, Acceptance 5.2)
+- [x] T040 [P] [US5] Validate `cmd_push` in `dilxc.sh` — verify `lxc file push` from host to container with default dest `/home/ubuntu/project/` (FR-021, Acceptance 5.3)
 - [x] T041 [US5] Validate bash `sync-project` function in `provision-container.sh` — verify same rsync command and excludes as `cmd_sync` (FR-006, Acceptance 5.4)
 - [x] T042 [US5] Validate bash `deploy` function in `provision-container.sh` — verify rsync to `/mnt/deploy` with mount check (FR-018, Acceptance 5.5)
-- [x] T043 [US5] Acceptance test: Add a file on host, run `sandbox.sh sync`, verify file appears in `/home/ubuntu/project` and `node_modules`/`.git` are excluded (SC-004)
+- [x] T043 [US5] Acceptance test: Add a file on host, run `dilxc.sh sync`, verify file appears in `/home/ubuntu/project` and `node_modules`/`.git` are excluded (SC-004)
 
 **Checkpoint**: User Story 5 validated — sync and file transfer work as specified
 
@@ -151,14 +151,14 @@
 
 ### Validation for User Story 6
 
-- [x] T044 [P] [US6] Validate `cmd_start` in `sandbox.sh` — verify `lxc start` with `require_container` precondition (Acceptance 6.1)
-- [x] T045 [P] [US6] Validate `cmd_stop` in `sandbox.sh` — verify `lxc stop` with `require_running` precondition (Acceptance 6.2)
-- [x] T046 [P] [US6] Validate `cmd_restart` in `sandbox.sh` — verify `lxc restart` with `require_running` precondition (Acceptance 6.3)
-- [x] T047 [P] [US6] Validate `cmd_status` in `sandbox.sh` — verify container info, IP address, and snapshot listing (Acceptance 6.4)
-- [x] T048 [P] [US6] Validate `cmd_shell` in `sandbox.sh` — verify bash shell as `ubuntu` user with TTY via `su - ubuntu` (FR-010, Acceptance 6.5)
-- [x] T049 [P] [US6] Validate `cmd_root` in `sandbox.sh` — verify root shell with TTY (Acceptance 6.6)
-- [x] T050 [US6] Validate `cmd_destroy` in `sandbox.sh` — verify confirmation prompt before `lxc delete` (FR-020, Acceptance 6.7)
-- [x] T051 [US6] Validate `cmd_exec` in `sandbox.sh` — verify command execution in `/home/ubuntu/project` with `printf %q` escaping (FR-011)
+- [x] T044 [P] [US6] Validate `cmd_start` in `dilxc.sh` — verify `lxc start` with `require_container` precondition (Acceptance 6.1)
+- [x] T045 [P] [US6] Validate `cmd_stop` in `dilxc.sh` — verify `lxc stop` with `require_running` precondition (Acceptance 6.2)
+- [x] T046 [P] [US6] Validate `cmd_restart` in `dilxc.sh` — verify `lxc restart` with `require_running` precondition (Acceptance 6.3)
+- [x] T047 [P] [US6] Validate `cmd_status` in `dilxc.sh` — verify container info, IP address, and snapshot listing (Acceptance 6.4)
+- [x] T048 [P] [US6] Validate `cmd_shell` in `dilxc.sh` — verify bash shell as `ubuntu` user with TTY via `su - ubuntu` (FR-010, Acceptance 6.5)
+- [x] T049 [P] [US6] Validate `cmd_root` in `dilxc.sh` — verify root shell with TTY (Acceptance 6.6)
+- [x] T050 [US6] Validate `cmd_destroy` in `dilxc.sh` — verify confirmation prompt before `lxc delete` (FR-020, Acceptance 6.7)
+- [x] T051 [US6] Validate `cmd_exec` in `dilxc.sh` — verify command execution in `/home/ubuntu/project` with `printf %q` escaping (FR-011)
 
 **Checkpoint**: User Story 6 validated — lifecycle management works as specified
 
@@ -168,14 +168,14 @@
 
 **Goal**: Verify Docker passthrough and log commands
 
-**Independent Test**: Run `sandbox.sh docker run hello-world` and verify Docker operates correctly
+**Independent Test**: Run `dilxc.sh docker run hello-world` and verify Docker operates correctly
 
 ### Validation for User Story 7
 
-- [x] T052 [US7] Validate `cmd_docker` in `sandbox.sh` — verify Docker command passthrough with `printf %q` escaping (FR-011, Acceptance 7.1, 7.2)
-- [x] T053 [US7] Validate `cmd_logs` in `sandbox.sh` — verify Docker container log display (Acceptance 7.3)
+- [x] T052 [US7] Validate `cmd_docker` in `dilxc.sh` — verify Docker command passthrough with `printf %q` escaping (FR-011, Acceptance 7.1, 7.2)
+- [x] T053 [US7] Validate `cmd_logs` in `dilxc.sh` — verify Docker container log display (Acceptance 7.3)
 - [x] T054 [US7] Validate nesting configuration — verify `security.nesting=true` in `setup-host.sh` enables Docker inside container (FR-001)
-- [x] T055 [US7] Acceptance test: Run `sandbox.sh docker run hello-world` and verify successful output (SC-002 prerequisite)
+- [x] T055 [US7] Acceptance test: Run `dilxc.sh docker run hello-world` and verify successful output (SC-002 prerequisite)
 
 **Checkpoint**: User Story 7 validated — Docker works inside the sandbox as specified
 
@@ -183,15 +183,15 @@
 
 ## Phase 10: User Story 8 — Multiple Sandboxes (Priority: P3)
 
-**Goal**: Verify `CLAUDE_SANDBOX` env var enables independent container targeting
+**Goal**: Verify `DILXC_CONTAINER` env var enables independent container targeting
 
 **Independent Test**: Create two sandboxes with different projects, verify each operates independently
 
 ### Validation for User Story 8
 
-- [x] T056 [US8] Validate `CLAUDE_SANDBOX` env var in `sandbox.sh` — verify container name defaults to `claude-sandbox` and is overridable (FR-015, Acceptance 8.1)
-- [x] T057 [US8] Validate `CLAUDE_SANDBOX` in `setup-host.sh` — verify `-n` flag and env var fallback per contracts/setup-host.md
-- [x] T058 [US8] Acceptance test: Set `CLAUDE_SANDBOX=test-b`, run `sandbox.sh status`, verify it targets `test-b` container (Acceptance 8.1, SC-006)
+- [x] T056 [US8] Validate `DILXC_CONTAINER` env var in `dilxc.sh` — verify container name defaults to `docker-lxc` and is overridable (FR-015, Acceptance 8.1)
+- [x] T057 [US8] Validate `DILXC_CONTAINER` in `setup-host.sh` — verify `-n` flag and env var fallback per contracts/setup-host.md
+- [x] T058 [US8] Acceptance test: Set `DILXC_CONTAINER=test-b`, run `dilxc.sh status`, verify it targets `test-b` container (Acceptance 8.1, SC-006)
 
 **Checkpoint**: User Story 8 validated — multiple sandboxes work independently
 
@@ -201,14 +201,14 @@
 
 **Goal**: Verify health-check reports pass/fail for all five components
 
-**Independent Test**: Run `sandbox.sh health-check` on healthy container; all checks pass
+**Independent Test**: Run `dilxc.sh health-check` on healthy container; all checks pass
 
 ### Validation for User Story 9
 
-- [x] T059 [US9] Validate `cmd_health_check` in `sandbox.sh` — verify checks for network, Docker, Claude Code, project directory, and source mount (FR-014, Acceptance 9.1)
+- [x] T059 [US9] Validate `cmd_health_check` in `dilxc.sh` — verify checks for network, Docker, Claude Code, project directory, and source mount (FR-014, Acceptance 9.1)
 - [x] T060 [US9] Validate health-check exit code — verify nonzero exit on any component failure (Acceptance 9.2)
 - [x] T061 [US9] Validate health-check output format — verify each component reports `ok` or `FAILED` per contracts/sandbox.md — **FIXED**: changed "missing"/"not mounted" to "FAILED", added `ok=false` for source mount
-- [x] T062 [US9] Acceptance test: Run `sandbox.sh health-check` on a working container and verify all five checks pass (SC-005)
+- [x] T062 [US9] Acceptance test: Run `dilxc.sh health-check` on a working container and verify all five checks pass (SC-005)
 
 **Checkpoint**: User Story 9 validated — health check works as specified
 
@@ -221,7 +221,7 @@
 - [x] T063 [P] Validate edge case: missing project directory at setup time — verify `setup-host.sh` fails with clear error before creating container — **FIXED**: added early validation of required `-p` flag before container creation
 - [x] T064 [P] Validate edge case: commands on non-existent container — verify `require_container` produces "container not found" with create instructions
 - [x] T065 [P] Validate edge case: commands on stopped container — verify `require_running` produces "container is STOPPED" with start instructions
-- [x] T066 Validate `sandbox.sh` case-based dispatch — verify all subcommands from contracts/sandbox.md are routed and `help` is the default
+- [x] T066 Validate `dilxc.sh` case-based dispatch — verify all subcommands from contracts/sandbox.md are routed and `help` is the default
 - [x] T067 Validate CLAUDE.md accuracy — verify Known Issues, Key Commands, and Editing Notes match the current implementation
 - [x] T068 Run quickstart.md validation — walk through quickstart.md end-to-end and verify each command works as documented (auth commands skipped — require browser OAuth)
 
@@ -241,14 +241,14 @@
 ### User Story Dependencies
 
 - **US1 (P1)**: Independent — `setup-host.sh` + `provision-container.sh` audit
-- **US2 (P1)**: Independent — `sandbox.sh` claude commands audit
+- **US2 (P1)**: Independent — `dilxc.sh` claude commands audit
 - **US3 (P1)**: Partially depends on US1 (API key path involves `setup-host.sh`)
-- **US4 (P2)**: Independent — `sandbox.sh` snapshot commands audit
-- **US5 (P2)**: Independent — `sandbox.sh` sync/pull/push + `provision-container.sh` functions
-- **US6 (P2)**: Independent — `sandbox.sh` lifecycle commands audit
+- **US4 (P2)**: Independent — `dilxc.sh` snapshot commands audit
+- **US5 (P2)**: Independent — `dilxc.sh` sync/pull/push + `provision-container.sh` functions
+- **US6 (P2)**: Independent — `dilxc.sh` lifecycle commands audit
 - **US7 (P3)**: Depends on US1 (nesting config in `setup-host.sh`)
 - **US8 (P3)**: Independent — env var handling across both host scripts
-- **US9 (P3)**: Independent — `sandbox.sh` health-check audit
+- **US9 (P3)**: Independent — `dilxc.sh` health-check audit
 
 ### Parallel Opportunities
 
@@ -281,12 +281,12 @@ Task: "Validate idempotent GPG key in provision-container.sh" # T022
 
 ```bash
 # Launch all independent lifecycle validations together:
-Task: "Validate cmd_start in sandbox.sh"    # T044
-Task: "Validate cmd_stop in sandbox.sh"     # T045
-Task: "Validate cmd_restart in sandbox.sh"  # T046
-Task: "Validate cmd_status in sandbox.sh"   # T047
-Task: "Validate cmd_shell in sandbox.sh"    # T048
-Task: "Validate cmd_root in sandbox.sh"     # T049
+Task: "Validate cmd_start in dilxc.sh"    # T044
+Task: "Validate cmd_stop in dilxc.sh"     # T045
+Task: "Validate cmd_restart in dilxc.sh"  # T046
+Task: "Validate cmd_status in dilxc.sh"   # T047
+Task: "Validate cmd_shell in dilxc.sh"    # T048
+Task: "Validate cmd_root in dilxc.sh"     # T049
 ```
 
 ---
@@ -317,8 +317,8 @@ With multiple reviewers:
 1. All complete Phase 1 + Phase 2 together
 2. Once Foundational is done:
    - Reviewer A: US1 + US3 (setup-host.sh + provision-container.sh focus)
-   - Reviewer B: US2 + US4 + US5 (sandbox.sh core commands)
-   - Reviewer C: US6 + US7 + US8 + US9 (sandbox.sh remaining commands)
+   - Reviewer B: US2 + US4 + US5 (dilxc.sh core commands)
+   - Reviewer C: US6 + US7 + US8 + US9 (dilxc.sh remaining commands)
 3. Phase 12: Polish done collaboratively
 
 ---


### PR DESCRIPTION
## Summary

- Add complete baseline specification documenting the existing implementation (spec, plan, contracts, data model, research, quickstart, tasks, checklists)
- Validate all 68 acceptance tasks against live LXC container, fixing script issues found during audit
- Rename project from `claude-lxc-sandbox` to `docker-in-lxc`: `sandbox.sh` → `dilxc.sh`, `CLAUDE_SANDBOX` → `DILXC_CONTAINER`, default container `docker-lxc`

## Test plan

- [x] All 68 spec tasks validated (T001–T068) across 9 user stories
- [x] All grep checks pass: no stale references to old names (`CLAUDE_SANDBOX`, `claude-sandbox`, `sandbox.sh`, `Claude Code LXD Sandbox`)
- [x] `bash -n` syntax check passes on all three scripts
- [x] `./dilxc.sh help` and `./setup-host.sh --help` output reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)